### PR TITLE
Changed bevy-hid to bevy_hid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "bevy-hid"
+name = "bevy_hid"
 version = "0.1.0"
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bevy-hid
+# Bevy_hid
 <div id="top"></div>
 
 [![Minimum Supported Rust Version]][Rust 1.56]
@@ -8,7 +8,7 @@ Support for the Windows [HID device protocol](https://docs.microsoft.com/en-us/w
 <!-- ABOUT THE PROJECT -->
 ## About The Project
 
-Bevy-hid is an alternative to the the default [bevy-gilrs](https://github.com/bevyengine/bevy/tree/main/crates/bevy_gilrs) crate, implimenting the [Human Interface Device](https://docs.microsoft.com/en-us/windows-hardware/drivers/hid/) Windows protocol instead.
+Bevy_hid is an alternative to the the default [bevy-gilrs](https://github.com/bevyengine/bevy/tree/main/crates/bevy_gilrs) crate, implimenting the [Human Interface Device](https://docs.microsoft.com/en-us/windows-hardware/drivers/hid/) Windows protocol instead.
 This is a more involved approach to peripheral connectivity and allows for the use of less standard devices as game input, as well as providing a simple yet powerful mapping system for unknown devices. 
 Because this approach takes advantage of the base bevy input system, it can seemlessly integrated into other input libraries (e.g. [LIM](https://crates.io/crates/leafwing-input-manager)) with no extra code required.
 


### PR DESCRIPTION
Great plugin with a lot of potentials! 🚀 As mentioned here by Alice, cargo is really poor at handling `-`, so using an underscore for the crate name eliminates the possibility of the same mishaps https://github.com/Leafwing-Studios/leafwing-input-manager/issues/160#issuecomment-1179759110. Also, the imports for the crate will be `use bevy_hid::...` either way, as rust doesn't support `-` in its import statement.
